### PR TITLE
Removed text that 0x prefix must be removed from wallet account address

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ ACCOUNT_ADDRESS=xxxxxxxxxx
 
 The `INFURA_RINKEBY` value is an endpoint address from [infura.io](https://infura.io), however it can be any valid address to an Ethereum network WebSocket endpoint.
 
-The `ACCOUNT_ADDRESS` is the address of a Ethereum wallet, not including the "0x" prefix.
+The `ACCOUNT_ADDRESS` is the address of a Ethereum wallet.
 
 If this configuration is in place the program can be run using cargo:
 
 ```bash
 cargo run
 ```
-


### PR DESCRIPTION
Thank you for this great tutorial! I was able to copy+paste my wallet account address from MetaMask to the .env file without first removing the 0x prefix, as recommended in the README file. I am suggesting this edit to help make the instructions a little simpler.